### PR TITLE
Now works for Node v0.2.5 (stable), and made debugging optional

### DIFF
--- a/lib/readability.js
+++ b/lib/readability.js
@@ -2123,7 +2123,7 @@ function removeReadabilityArtifacts() {
 		document.title = titleContainer.innerHTML;
 	}
 	
-	var contentContainer = document.getElementById('readability-content');
+	var contentContainer = document.getElementById('readability-page-1');
 	if (null !== contentContainer) {
 		document.body.innerHTML = contentContainer.innerHTML;
 	}

--- a/lib/readability.js
+++ b/lib/readability.js
@@ -19,7 +19,7 @@ var dbg = (typeof console !== 'undefined') ? function(s) {
 **/
 var readability = {
     version:                '1.7.1',
-    debugging:              false,
+    debugging:              true,
     emailSrc:               'http://lab.arc90.com/experiments/readability/email.php',
     iframeLoads:             0,
     convertLinksToFootnotes: false,

--- a/lib/readability.js
+++ b/lib/readability.js
@@ -2129,6 +2129,31 @@ function removeReadabilityArtifacts() {
 	}
 }
 
+function removeClassNames(e) {
+	var e = e || document;
+	var cur = e.firstChild;
+
+	if(!e) {
+		return; }
+
+	// Remove any root class names, if we're able.
+	if(e.className) {
+		e.className = "";
+	}
+
+	// Go until there are no more child nodes
+	while ( cur !== null ) {
+		if ( cur.nodeType === 1 ) {
+			// Remove class names
+			if(e.className) {
+				e.className = "";
+			}
+			removeClassNames(cur);
+		}
+		cur = cur.nextSibling;
+	}           
+}
+
 function start(w, cb) {
 	window = w;
 	document = w.document;
@@ -2147,6 +2172,7 @@ function start(w, cb) {
 	MyProfiler.report();
 	
 	removeReadabilityArtifacts();
+	removeClassNames();
 
 	//dbg('[Readability] done');
 	cb(document.body.innerHTML);

--- a/lib/readability.js
+++ b/lib/readability.js
@@ -2127,8 +2127,6 @@ function removeReadabilityArtifacts() {
 	if (null !== contentContainer) {
 		document.body.innerHTML = contentContainer.innerHTML;
 	}
-	
-	console.log(document.body.innerHTML);
 }
 
 function start(w, cb) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
        "jsdom": ">=0.1.20",
        "htmlparser": ">=1.7.0"
     },
-    "engines" : { "node" : ">=0.3.1" },
+    "engines" : { "node" : ">=0.2.5" },
     "directories": {
         "lib": "lib"
     },


### PR DESCRIPTION
Hey,

Great work on the port. We made our own port for our project, but found yours shortly afterwards so we've decided to just use yours and contribute to it.

The attached changes allow node-readability to be used with the latest stable version of Node (0.2.5), by removing the dependency on the `util` module. Also, it allows debugging to be optional, by setting `readability.debugging` before the call to `readability.parse`.

Hope this helps,
Chetan
