### PR TITLE
Debugging option flag should be set before all dbg() calls.

### DIFF
--- a/lib/readability.js
+++ b/lib/readability.js
@@ -2226,6 +2226,9 @@ exports.parse = function parse(theHtml, url, options, callback) {
 	};
 	options = Utils.extend({}, defaultOptions, options);
 	
+	// Debugging flag must be set before all dbg statements
+	readability.debugging = options.debug;
+	
 	var startTime = new Date().getTime();
 	//dbg(html);
 	var html = theHtml.replace(/<script[^>]*>([\s\S]*?)<\/script>/gi, '');


### PR DESCRIPTION
Added an additional line to set it near the top of parse(). It is normally set in start(), but start() is called too late (after some dbg() statements).
